### PR TITLE
[Android] Return entire MRZ info for passport & upgrade tesseract4android to support 16kb page size for Android 15

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -101,7 +101,7 @@ dependencies {
   implementation "androidx.camera:camera-view:1.3.3"
 
   coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
-  implementation 'cz.adaptech:tesseract4android:4.1.1'
+  implementation 'cz.adaptech:tesseract4android:4.9.0'
 
   implementation 'org.jmrtd:jmrtd:0.7.18'
 }

--- a/android/src/main/java/com/mrzreader/utils/OcrUtil.kt
+++ b/android/src/main/java/com/mrzreader/utils/OcrUtil.kt
@@ -231,7 +231,7 @@ class OcrUtil {
             val mrzInfoTemp: MRZInfo? =
               buildTempMrz(documentNumber, dateOfBirthDay, expiryDate, docType)
             if (mrzInfoTemp != null) {
-              mrzInfo = mrzInfoTemp
+              mrzInfo = matcherPassportTD3Line1 + matcherPassportTD3Line2
             }
           }
 

--- a/android/src/main/java/com/mrzreader/utils/OcrUtil.kt
+++ b/android/src/main/java/com/mrzreader/utils/OcrUtil.kt
@@ -228,11 +228,9 @@ class OcrUtil {
           }
           //---------------------
           if (isValidMrz) {
-            val mrzInfoTemp: MRZInfo? =
-              buildTempMrz(documentNumber, dateOfBirthDay, expiryDate, docType)
-            if (mrzInfoTemp != null) {
-              mrzInfo = matcherPassportTD3Line1 + matcherPassportTD3Line2
-            }
+            val line1 = matcherPassportTD3Line1.group(0).toString()
+            val line2 = matcherPassportTD3Line2.group(0).toString()
+            mrzInfo = MRZInfo(line1 + line2)
           }
 
           return mrzInfo


### PR DESCRIPTION
This change makes Android the same as iOS for MRZ value returned for passports. It should contain all the information scanned, not just the 4 values picked. It also returns the 2 lines combined together without a line break just like iOS.

I see the rest of the code also selectively returns part of the MRZ but I don't have any Turkish ID cards or other MRZ to test with.

As of Nov 2025, apps with the old 4kb page size cannot be submitted to Play Store anymore so the tesseract4android is a mandatory upgrade.